### PR TITLE
feat(cli): read URLs to shorten from stdin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +185,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 name = "bitcli"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "clap",
  "config",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ debug = true
 codegen-units = 1
 
 [dependencies]
+async-stream = "0.3.5"
 clap = { version = "4.5", features = ["derive", "env"] }
 config = "0.14"
 futures-util = "0.3.30"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -125,8 +125,9 @@ impl From<&Command> for Options {
 
 #[derive(Args, Debug)]
 pub struct ShortenArgs {
-    // TODO: allow reading URL(s) from stdin
     /// URLs to shorten
+    ///
+    /// If none given as program arguments, then the application will try to read them from stdin.
     #[arg(num_args(1..))]
     pub urls: Vec<Url>,
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,9 @@ pub enum Error {
     UnknownGroupGUID(&'static str),
 
     #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
     Http(#[from] reqwest::Error),
 
     #[error(transparent)]

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,39 @@
+use std::error::Error;
+use std::str::FromStr;
+
+use async_stream::try_stream;
+use futures_util::TryStream;
+use tokio::io::{self, AsyncBufReadExt as _, BufReader};
+
+use crate::error::Result;
+
+pub fn read_input<T>() -> impl TryStream<Item = Result<T>>
+where
+    T: FromStr + 'static,
+    <T as FromStr>::Err: Error + Send + Sync,
+{
+    try_stream! {
+        let mut stdin = BufReader::new(io::stdin());
+        let mut buf = String::new();
+
+        loop {
+            let n = stdin.read_line(&mut buf).await?;
+
+            if n == 0 {
+                break;
+            }
+
+            yield buf.trim().parse::<T>().map_err(invalid_input)?;
+
+            buf.clear();
+        }
+    }
+}
+
+#[inline]
+fn invalid_input<E>(e: E) -> std::io::Error
+where
+    E: Into<Box<dyn Error + Send + Sync>>,
+{
+    std::io::Error::new(std::io::ErrorKind::InvalidInput, e)
+}


### PR DESCRIPTION
This PR adds support for reading (lazily) URLs to be shortened from stdin when none is given as in the argument list.

The standard input is expected to yield one URL per line and currently is expected to be non-empty. That is, the application will wait for at least one input line indefinitely. This might be leveraged later.

Also note that the program will terminate on the first URL parsing error and in that case the remaining input won't be processed (i.e., no further API requests will be issued).