### PR TITLE
feat(cli): return immediately when stdin is empty

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,9 +39,10 @@ async fn main() {
     match cmd {
         Command::Shorten(args) => {
             let urls = if args.urls.is_empty() {
-                io::read_input::<url::Url>()
-                    .map(|url| crash_if_err!(url))
-                    .boxed()
+                let Some(urls) = io::read_input::<url::Url>() else {
+                    return;
+                };
+                urls.map(|url| crash_if_err!(url)).boxed()
             } else {
                 stream::iter(args.urls).boxed()
             };


### PR DESCRIPTION
With this change, calling `bitcli` (or `bitcli shorten`) without any arguments will no longer wait for the standard input indefinitely if it's empty and its handle does not refer to a terminal/tty.