### PR TITLE
chore: update release profile config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,9 @@ keywords = ["bitly", "cli", "url", "shortener"]
 rust-version = "1.74"
 
 [profile.release]
-debug = true
 codegen-units = 1
+strip = true
+lto = true
 
 [dependencies]
 async-stream = "0.3.5"


### PR DESCRIPTION
This PR changes the configuration of the `release` profile in the following ways:
 1. Strip all symbols, including debug info
 2. Enables LTO

Note that the same config can be found in tools such as `fd`, `sd`, and a very similar one in `ripgrep`.